### PR TITLE
add job variable to batch timeout

### DIFF
--- a/dashboard/opentelemetry-collector-dashboard.json
+++ b/dashboard/opentelemetry-collector-dashboard.json
@@ -1483,7 +1483,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(${metric:value}(otelcol_processor_batch_timeout_trigger_send{processor=~\"$processor\"}[$__rate_interval])) by (processor)",
+          "expr": "sum(${metric:value}(otelcol_processor_batch_timeout_trigger_send{processor=~\"$processor\",job=\"$job\"}[$__rate_interval])) by (processor)",
           "format": "time_series",
           "hide": false,
           "instant": false,


### PR DESCRIPTION
found this whilst testing metrics on some new collectors. the dashboard showed metrics when others didn't as the collector had only just started