### PR TITLE
Fix regex for job name

### DIFF
--- a/dashboard/opentelemetry-collector-dashboard.json
+++ b/dashboard/opentelemetry-collector-dashboard.json
@@ -6032,7 +6032,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/.*{.*job=\"([a-zA-Z0-9_-/]+)\".*}/",
+        "regex": "/.*{.*job=\"([a-zA-Z0-9_\/-]+)\".*}/",
         "sort": 1,
         "type": "query"
       },


### PR DESCRIPTION
This PR fixes #10 where regex is faulty. Currently, Grafana dashboard does not visualize any data and complains about "Invalid regular expression, Range out of order in character class".

This should fix the regex and allow to use `/` in job names.

Regex tested in validator, dashboard tested locally with Grafana v11.6.1 (ae23ead4d9).